### PR TITLE
Make pushed batch size configurable

### DIFF
--- a/client.go
+++ b/client.go
@@ -40,8 +40,8 @@ func (c *Client) Push(ctx context.Context) (httpext.Response, error) {
 	return c.PushParametrized(ctx, 5, 500, 1000)
 }
 
-func (c *Client) PushParametrized(ctx context.Context, streams, minLogs, maxLogs int) (httpext.Response, error) {
-	entries := generateEntries(ctx, c.cfg.TenantID, c.cfg.Labels, streams, minLogs, maxLogs)
+func (c *Client) PushParametrized(ctx context.Context, streams, minBatchSize, maxBatchSize int) (httpext.Response, error) {
+	entries := generateEntries(ctx, c.cfg.TenantID, c.cfg.Labels, streams, minBatchSize, maxBatchSize)
 	batch := newBatch(entries...)
 	return c.pushBatch(ctx, batch)
 }

--- a/loki.go
+++ b/loki.go
@@ -9,12 +9,16 @@ import (
 	gofakeit "github.com/brianvoe/gofakeit/v6"
 	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modules"
+	"go.k6.io/k6/stats"
 )
 
 var (
 	DefaultProtobufRatio = 0.9
 	DefaultPushTimeout   = 10000
 	DefaultUserAgent     = "xk6-loki/0.0.1"
+
+	ClientUncompressedBytes = stats.New("loki_client_uncompressed_bytes", stats.Counter, stats.Data)
+	ClientLines             = stats.New("loki_client_lines", stats.Counter, stats.Default)
 )
 
 // init registers the Go module as Javascript module for k6


### PR DESCRIPTION
In order to mimic real-world scenarios more realistically we want to
have the batch size of a push request configurable instead of the number
of log lines.

This change also adds two custom metrics which track the size of the
uncompressed log line data as well as the amount of lines pushed.

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>