### PR TITLE
Report any 2xx reponse as successful request

### DIFF
--- a/client.go
+++ b/client.go
@@ -244,5 +244,6 @@ func (c *Client) send(ctx context.Context, state *lib.State, buf []byte, useProt
 }
 
 func ResponseCallback(n int) bool {
-	return n == 200
+	// report all 2xx respones as successful requests
+	return n/100 == 2
 }


### PR DESCRIPTION
Loki requests return with HTTP 204 (No Content) when pushing logs.
Any 2xx status code indicates a successful HTTP response, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#successful_responses

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>