### PR TITLE
Reduce the amount of max active streams

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	fake "github.com/brianvoe/gofakeit/v6"
-	"github.com/brianvoe/gofakeit/v6/data"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/grafana/loki/pkg/logproto"
@@ -203,13 +202,24 @@ func generateValues(ff FakeFunc, n int) []string {
 
 // newLabelPool creates a "pool" of values for each label name
 func newLabelPool(faker *fake.Faker, cardinalities map[string]int) LabelPool {
-	return LabelPool{
-		"format":    []string{"apache_common", "apache_combined", "apache_error", "rfc3164", "rfc5424", "json"}, // needs to match the available flog formats
-		"os":        []string{"darwin", "linux", "windows"},
-		"namespace": generateValues(faker.BS, cardinalities["namespace"]),
-		"app":       generateValues(faker.AppName, cardinalities["app"]),
-		"pod":       generateValues(faker.BS, cardinalities["pod"]),
-		"language":  data.Data["language"]["short"],
-		"word":      data.Data["word"]["noun"],
+	lb := LabelPool{
+		"format": []string{"apache_common", "apache_combined", "apache_error", "rfc3164", "rfc5424", "json"}, // needs to match the available flog formats
+		"os":     []string{"darwin", "linux", "windows"},
 	}
+	if n, ok := cardinalities["namespace"]; ok {
+		lb["namespace"] = generateValues(faker.BS, n)
+	}
+	if n, ok := cardinalities["app"]; ok {
+		lb["app"] = generateValues(faker.AppName, n)
+	}
+	if n, ok := cardinalities["pod"]; ok {
+		lb["pod"] = generateValues(faker.BS, n)
+	}
+	if n, ok := cardinalities["language"]; ok {
+		lb["language"] = generateValues(faker.LanguageAbbreviation, n)
+	}
+	if n, ok := cardinalities["word"]; ok {
+		lb["word"] = generateValues(faker.Noun, n)
+	}
+	return lb
 }

--- a/client.go
+++ b/client.go
@@ -165,7 +165,9 @@ func (c *Client) sendQuery(ctx context.Context, q *Query) (httpext.Response, err
 }
 
 func (c *Client) Push(ctx context.Context) (httpext.Response, error) {
-	return c.PushParametrized(ctx, 5, 500, 1000)
+	// 5 streams per batch
+	// batch size between 800KB and 1MB
+	return c.PushParametrized(ctx, 5, 800*1024, 1024*1024)
 }
 
 func (c *Client) PushParametrized(ctx context.Context, streams, minBatchSize, maxBatchSize int) (httpext.Response, error) {

--- a/loki.go
+++ b/loki.go
@@ -51,7 +51,7 @@ func (r *Loki) XConfig(ctxPtr *context.Context, urlString string, timeoutMs int,
 		cardinalities = map[string]int{
 			"app":       5,
 			"namespace": 10,
-			"pod":       100,
+			"pod":       50,
 		}
 	}
 


### PR DESCRIPTION
The maximum amount of active streams is defined by the product of all
label values. This value was extremely high by default (6 × 3 × 5 × 10 × 50 × 177 × 997 = 7,941,105,000)

By making the cardinality of all label (except format and os) configurable, one can also control the
maximum amount of unique streams that can be produced.

Labels and their max amount of values are:

| name      | max values      |
| ========= | =============== |
| instance  | 1 per k6 worker | (not configurable)
| format    | 6               | (not configurable)
| os        | 3               | (not configurable)
| namespace | 169             |
| app       | ?               |
| pod       | 169             |
| language  | 177             |
| word      | 997             |

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>