### PR TITLE
README: fix `git clone` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 1. Checkout `grafana/xk6-loki`
 
    ```bash
-   git clone github.com/grafana/xk6-loki
+   git clone https://github.com/grafana/xk6-loki
    cd xk6-loki
    ```
 


### PR DESCRIPTION
`git clone` is missing scheme `https` on the repo URL.