### PR TITLE
Add additional metrics for total bytes/lines processed

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,12 +171,15 @@ The extension collects metrics that are printed in the
 [end-of-test summary](https://k6.io/docs/results-visualization/end-of-test-summary/) in addition to the built-in metrics.
 
 ### Query metrics
+
 These metrics are collected only for instant and range queries.
 
 | name                              | description                                  |
 |-----------------------------------|----------------------------------------------|
 | `loki_bytes_processed_per_second` | amount of bytes processed by Loki per second |
+| `loki_bytes_processed_total`      | total amount of bytes processed by Loki      |
 | `loki_lines_processed_per_second` | amount of lines processed by Loki per second |
+| `loki_lines_processed_total`      | total amount of lines processed by Loki      |
 
 ### Write metrics
 

--- a/client.go
+++ b/client.go
@@ -29,7 +29,9 @@ const (
 )
 
 var (
+	BytesProcessedTotal      = k6_stats.New("loki_bytes_processed_total", k6_stats.Counter, k6_stats.Data)
 	BytesProcessedPerSeconds = k6_stats.New("loki_bytes_processed_per_second", k6_stats.Trend, k6_stats.Data)
+	LinesProcessedTotal      = k6_stats.New("loki_lines_processed_total", k6_stats.Counter, k6_stats.Default)
 	LinesProcessedPerSeconds = k6_stats.New("loki_lines_processed_per_second", k6_stats.Trend, k6_stats.Default)
 )
 
@@ -292,9 +294,21 @@ func reportMetricsFromStats(ctx context.Context, response httpext.Response, quer
 	k6_stats.PushIfNotDone(ctx, lib.GetState(ctx).Samples, k6_stats.ConnectedSamples{
 		Samples: []k6_stats.Sample{
 			{
+				Metric: BytesProcessedTotal,
+				Tags:   tags,
+				Value:  float64(responseWithStats.Data.Stats.Summary.TotalBytesProcessed),
+				Time:   now,
+			},
+			{
 				Metric: BytesProcessedPerSeconds,
 				Tags:   tags,
 				Value:  float64(responseWithStats.Data.Stats.Summary.BytesProcessedPerSecond),
+				Time:   now,
+			},
+			{
+				Metric: LinesProcessedTotal,
+				Tags:   tags,
+				Value:  float64(responseWithStats.Data.Stats.Summary.TotalLinesProcessed),
 				Time:   now,
 			},
 			{


### PR DESCRIPTION
The response from Loki instant and range queries also contain statistics
about the total amount of bytes and lines processed by the request.
This commit exposes this data as custom k6 metrics
`loki_bytes_processed_total` and `loki_lines_processed_total`.

This helps to analyze and understand the amount of data processed during
a load test.

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>