### PR TITLE
Extend simple example with queries

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -34,8 +34,35 @@ export const options = {
   iterations: 10,
 };
 
+/**
+ * "main" function for each VU iteration
+ */
 export default () => {
-  var res = client.pushParameterized(2, 500 * KB, 1 * MB);
+  // Push request with 10 streams and uncompressed logs between 800KB and 2MB
+  var res = client.pushParameterized(10, 800 * KB, 2 * MB);
+  // Check for successful write
   check(res, { 'successful write': (res) => res.status == 204 });
+
+  // Pick a random log format from label pool
+  let format = randomChoice(conf.labels["format"]);
+
+  // Execute instant query with limit 1
+  res = client.instantQuery(`count_over_time({format="${format}"}[1m])`, 1)
+  // Check for successful read
+  check(res, { 'successful instant query': (res) => res.status == 200 });
+
+  // Execute range query over last 5m and limit 1000
+  res = client.rangeQuery(`{format="${format}"}`, "5m", 1000)
+  // Check for successful read
+  check(res, { 'successful range query': (res) => res.status == 200 });
+
+  // Wait before next iteration
   sleep(1);
+}
+
+/**
+ * Helper function to get random item from array
+ */
+function randomChoice(items) {
+  return items[Math.floor(Math.random() * items.length)];
 }


### PR DESCRIPTION
The simple example should contain both write and read, but the latter
was still missing from that example.

I extended the example to only contain instant and range queries, to keep it
to a very minimum.

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>