### PR TITLE
Add support for pushing logs in `logfmt` format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GO_FILES := $(shell find . -type f -name "*.go" -print)
 
 k6: $(GO_FILES)
 	xk6 build \
-		--replace "github.com/mingrammer/flog=github.com/chaudum/flog@v0.4.4-0.20211115125504-92153be038e6" \
+		--replace "github.com/mingrammer/flog=github.com/chaudum/flog@v0.4.4-0.20220419113107-eb2f67f18b99" \
 	  --with "github.com/grafana/xk6-loki=$(PWD)"
 
 go.sum: $(GO_FILES) go.mod

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Execute a series query ([GET /loki/api/v1/series](https://grafana.com/docs/loki/
 | name | values | notes |
 | ---- | ------ | ----- |
 | instance | fixed: 1 per k6 worker | |
-| format | fixed: apache_common, apache_combined, apache_error, rfc3164, rfc5424, json | This label defines how the log lines of a stream are formatted. |
+| format | fixed: apache_common, apache_combined, apache_error, rfc3164, rfc5424, json, logfmt | This label defines how the log lines of a stream are formatted. |
 | os | fixed: darwin, linux, windows | - |
 | namespace | variable | [^1] |
 | app | variable | [^1] |

--- a/batch.go
+++ b/batch.go
@@ -210,7 +210,7 @@ func generateValues(ff FakeFunc, n int) []string {
 // newLabelPool creates a "pool" of values for each label name
 func newLabelPool(faker *fake.Faker, cardinalities map[string]int) LabelPool {
 	lb := LabelPool{
-		"format": []string{"apache_common", "apache_combined", "apache_error", "rfc3164", "rfc5424", "json"}, // needs to match the available flog formats
+		"format": []string{"apache_common", "apache_combined", "apache_error", "rfc3164", "rfc5424", "json", "logfmt"}, // needs to match the available flog formats
 		"os":     []string{"darwin", "linux", "windows"},
 	}
 	if n, ok := cardinalities["namespace"]; ok {

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,6 @@ require (
 	go.k6.io/k6 v0.38.0
 )
 
-replace github.com/mingrammer/flog => github.com/chaudum/flog v0.4.4-0.20211115125504-92153be038e6
+replace github.com/mingrammer/flog => github.com/chaudum/flog v0.4.4-0.20220419113107-eb2f67f18b99
 
 replace google.golang.org/grpc => google.golang.org/grpc v1.40.0

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chaudum/flog v0.4.4-0.20211115125504-92153be038e6 h1:BJooVLaaS3kqhQSzrFNFQ90pUybLVrhMMFhi89oX4Vk=
-github.com/chaudum/flog v0.4.4-0.20211115125504-92153be038e6/go.mod h1:HnDRe7HbtBOHZ4qeD+yCHXM8pR7qq7hl1rUI/tLGDKA=
+github.com/chaudum/flog v0.4.4-0.20220419113107-eb2f67f18b99 h1:jAtWDP8BytgtCzaxDzK/fZusSQbIaK0d9B6xwPpQCoU=
+github.com/chaudum/flog v0.4.4-0.20220419113107-eb2f67f18b99/go.mod h1:HnDRe7HbtBOHZ4qeD+yCHXM8pR7qq7hl1rUI/tLGDKA=
 github.com/chromedp/cdproto v0.0.0-20200116234248-4da64dd111ac/go.mod h1:PfAWWKJqjlGFYJEidUM6aVIWPr0EpobeyVWEEmplX7g=
 github.com/chromedp/cdproto v0.0.0-20200424080200-0de008e41fa0/go.mod h1:PfAWWKJqjlGFYJEidUM6aVIWPr0EpobeyVWEEmplX7g=
 github.com/chromedp/chromedp v0.5.3/go.mod h1:YLdPtndaHQ4rCpSpBG+IPpy9JvX0VD+7aaLxYgYj28w=


### PR DESCRIPTION
Updating `flog` allows to generate logs in `logfmt` format.

Diff: https://github.com/chaudum/flog/compare/92153be038e6...eb2f67f18b99

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>