### PR TITLE
allow setting different tenantIds than the basic auth username

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
@@ -40,7 +41,7 @@ type Config struct {
 	URL           url.URL
 	UserAgent     string
 	Timeout       time.Duration
-	TenantID      string
+	TenantIDs     []string
 	Labels        LabelPool
 	ProtobufRatio float64
 }
@@ -192,8 +193,8 @@ func (c *Client) sendQuery(q *Query) (httpext.Response, error) {
 
 	r.Header.Set("User-Agent", c.cfg.UserAgent)
 	r.Header.Set("Accept", ContentTypeJSON)
-	if c.cfg.TenantID != "" {
-		r.Header.Set("X-Scope-OrgID", c.cfg.TenantID)
+	if len(c.cfg.TenantIDs) > 0 {
+		r.Header.Set("X-Scope-OrgID", strings.Join(c.cfg.TenantIDs, "|"))
 	} else {
 		r.Header.Set("X-Scope-OrgID", fmt.Sprintf("%s-%d", TenantPrefix, state.VUID))
 	}
@@ -284,8 +285,8 @@ func (c *Client) send(state *lib.State, buf []byte, useProtobuf bool) (httpext.R
 
 	r.Header.Set("User-Agent", c.cfg.UserAgent)
 	r.Header.Set("Accept", ContentTypeJSON)
-	if c.cfg.TenantID != "" {
-		r.Header.Set("X-Scope-OrgID", c.cfg.TenantID)
+	if len(c.cfg.TenantIDs) == 0 {
+		r.Header.Set("X-Scope-OrgID", strings.Join(c.cfg.TenantIDs, "|"))
 	} else {
 		r.Header.Set("X-Scope-OrgID", fmt.Sprintf("%s-%d", TenantPrefix, state.VUID))
 	}

--- a/loki.go
+++ b/loki.go
@@ -144,7 +144,9 @@ func (r *Loki) config(c goja.ConstructorCall) *goja.Object {
 		common.Throw(rt, fmt.Errorf("Config constructor expects Labels as fifth argument"))
 	}
 
-	initEnv.Logger.Debug(fmt.Sprintf("url=%s timeoutMs=%d protobufRatio=%f cardinalities=%v", urlString, timeoutMs, protobufRatio, cardinalities))
+	tenantId := c.Argument(5).String()
+
+	initEnv.Logger.Debug(fmt.Sprintf("url=%s timeoutMs=%d protobufRatio=%f cardinalities=%v tenantId=%s", urlString, timeoutMs, protobufRatio, cardinalities, tenantId))
 
 	faker := gofakeit.New(12345)
 
@@ -153,7 +155,11 @@ func (r *Loki) config(c goja.ConstructorCall) *goja.Object {
 		panic(err)
 	}
 
-	if u.User.Username() == "" {
+	if tenantId == "" {
+		tenantId = u.User.Username()
+	}
+
+	if tenantId == "" {
 		initEnv.Logger.Warn("Running in multi-tenant-mode. Each VU has its own X-Scope-OrgID")
 	}
 
@@ -171,7 +177,7 @@ func (r *Loki) config(c goja.ConstructorCall) *goja.Object {
 	config := &Config{
 		URL:           *u,
 		UserAgent:     DefaultUserAgent,
-		TenantID:      u.User.Username(),
+		TenantID:      tenantId,
 		Timeout:       time.Duration(timeoutMs) * time.Millisecond,
 		Labels:        labels,
 		ProtobufRatio: protobufRatio,


### PR DESCRIPTION
This allows using the extension against a loki that's behind HTTP auth, but tenant IDs don't match 1:1 to basic auth username (such as the setup I'm working on, which uses tenants for book-keeping but not for authentication). Multitenant queries are also now supported.

I kept the code that defaults to the basic auth user name as tenant ID, but maybe that could be also dropped?
