### PR TITLE
Refactor extension config and random data generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ GO_FILES := $(shell find . -type f -name "*.go" -print)
 
 k6: $(GO_FILES)
 	xk6 build master \
-		--replace "github.com/mingrammer/flog=github.com/chaudum/flog@v0.4.4-0.20220419113107-eb2f67f18b99" \
 		--replace "google.golang.org/grpc=google.golang.org/grpc@v1.45.0" \
 		--replace "github.com/hashicorp/consul=github.com/hashicorp/consul@v1.5.1" \
 		--replace "github.com/gocql/gocql=github.com/grafana/gocql@v0.0.0-20200605141915-ba5dc39ece85" \

--- a/batch.go
+++ b/batch.go
@@ -176,7 +176,11 @@ func (c *Client) newBatch(pool LabelPool, numStreams, minBatchSize, maxBatchSize
 			common.Throw(c.vu.Runtime(), fmt.Errorf("%s is not a valid log format", logFmt))
 		}
 		var line string
-		for ; batch.Bytes < maxSizePerStream; batch.Bytes += len(line) {
+
+		// We have batch.Bytes so far, and each stream is allotted around
+		// maxSizePerStream, so our final byte this stream should be:
+		streamMaxByte := maxSizePerStream * (i + 1)
+		for ; batch.Bytes < streamMaxByte; batch.Bytes += len(line) {
 			now = time.Now()
 			line = c.flog.LogLine(logFmt, now)
 			stream.Entries = append(stream.Entries, logproto.Entry{

--- a/batch.go
+++ b/batch.go
@@ -8,12 +8,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/xk6-loki/flog"
+
 	fake "github.com/brianvoe/gofakeit/v6"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/grafana/loki/pkg/logproto"
 	json "github.com/mailru/easyjson"
-	"github.com/mingrammer/flog/flog"
 	"github.com/prometheus/common/model"
 	"go.k6.io/k6/js/common"
 )

--- a/batch_test.go
+++ b/batch_test.go
@@ -38,12 +38,13 @@ func BenchmarkNewBatch(b *testing.B) {
 	labels := newLabelPool(faker, cardinalities)
 
 	c := Client{
-		vu: vu,
+		vu:     vu,
+		labels: transformLabelPool(labels),
 	}
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = c.newBatch(labels, streams, minBatchSize, maxBatchSize)
+		_ = c.newBatch(streams, minBatchSize, maxBatchSize)
 	}
 }
 
@@ -76,9 +77,10 @@ func BenchmarkEncode(b *testing.B) {
 	labels := newLabelPool(faker, cardinalities)
 
 	c := Client{
-		vu: vu,
+		vu:     vu,
+		labels: transformLabelPool(labels),
 	}
-	batch := c.newBatch(labels, streams, minBatchSize, maxBatchSize)
+	batch := c.newBatch(streams, minBatchSize, maxBatchSize)
 
 	b.Run("encode protobuf", func(b *testing.B) {
 		b.ReportAllocs()

--- a/client.go
+++ b/client.go
@@ -11,8 +11,8 @@ import (
 	"path"
 	"time"
 
+	"github.com/brianvoe/gofakeit/v6"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
-	"github.com/sirupsen/logrus"
 	"go.k6.io/k6/js/modules"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/netext/httpext"
@@ -31,9 +31,9 @@ const (
 type Client struct {
 	vu      modules.VU
 	client  *http.Client
-	logger  logrus.FieldLogger
 	cfg     *Config
 	metrics lokiMetrics
+	faker   *gofakeit.Faker
 }
 
 type Config struct {
@@ -41,8 +41,10 @@ type Config struct {
 	UserAgent     string
 	Timeout       time.Duration
 	TenantID      string
+	Cardinalities map[string]int
 	Labels        LabelPool
 	ProtobufRatio float64
+	RandSeed      int64
 }
 
 func (c *Client) InstantQuery(logQuery string, limit int) (httpext.Response, error) {

--- a/client.go
+++ b/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
 	"github.com/grafana/xk6-loki/flog"
+	"github.com/prometheus/common/model"
 	"go.k6.io/k6/js/modules"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/netext/httpext"
@@ -29,6 +30,11 @@ const (
 	TenantPrefix = "xk6-tenant"
 )
 
+type labelValues struct {
+	name   model.LabelName
+	values []string
+}
+
 type Client struct {
 	vu      modules.VU
 	client  *http.Client
@@ -37,6 +43,7 @@ type Client struct {
 	rand    *rand.Rand
 	faker   *gofakeit.Faker
 	flog    *flog.Flog
+	labels  []labelValues
 }
 
 type Config struct {
@@ -242,7 +249,7 @@ func (c *Client) PushParameterized(streams, minBatchSize, maxBatchSize int) (htt
 		return *httpext.NewResponse(), errors.New("state is nil")
 	}
 
-	batch := c.newBatch(c.cfg.Labels, streams, minBatchSize, maxBatchSize)
+	batch := c.newBatch(streams, minBatchSize, maxBatchSize)
 	return c.pushBatch(batch)
 }
 

--- a/client.go
+++ b/client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
+	"github.com/grafana/xk6-loki/flog"
 	"go.k6.io/k6/js/modules"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/netext/httpext"
@@ -33,7 +34,9 @@ type Client struct {
 	client  *http.Client
 	cfg     *Config
 	metrics lokiMetrics
+	rand    *rand.Rand
 	faker   *gofakeit.Faker
+	flog    *flog.Flog
 }
 
 type Config struct {
@@ -254,7 +257,7 @@ func (c *Client) pushBatch(batch *Batch) (httpext.Response, error) {
 
 	// Use snappy encoded Protobuf for 90% of the requests
 	// Use JSON encoding for 10% of the requests
-	encodeSnappy := rand.Float64() < c.cfg.ProtobufRatio
+	encodeSnappy := c.rand.Float64() < c.cfg.ProtobufRatio
 	if encodeSnappy {
 		buf, _, err = batch.encodeSnappy()
 	} else {

--- a/flog/LICENSE
+++ b/flog/LICENSE
@@ -1,0 +1,24 @@
+This code was copied with heavy modifications from https://github.com/chaudum/flog,
+which itself was a fork of https://github.com/mingrammer/flog, with the following license:
+
+MIT License
+
+Copyright (c) 2018 mingrammer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/flog/flog.go
+++ b/flog/flog.go
@@ -1,0 +1,29 @@
+package flog
+
+import (
+	"time"
+)
+
+// NewLog creates a log for given format
+func NewLog(format string, t time.Time) string {
+	switch format {
+	case "apache_common":
+		return NewApacheCommonLog(t)
+	case "apache_combined":
+		return NewApacheCombinedLog(t)
+	case "apache_error":
+		return NewApacheErrorLog(t)
+	case "rfc3164":
+		return NewRFC3164Log(t)
+	case "rfc5424":
+		return NewRFC5424Log(t)
+	case "common_log":
+		return NewCommonLogFormat(t)
+	case "json":
+		return NewJSONLogFormat(t)
+	case "logfmt":
+		return NewLogFmtLogFormat(t)
+	default:
+		return ""
+	}
+}

--- a/flog/flog.go
+++ b/flog/flog.go
@@ -1,28 +1,39 @@
 package flog
 
 import (
+	"math/rand"
 	"time"
+
+	"github.com/brianvoe/gofakeit/v6"
 )
 
-// NewLog creates a log for given format
-func NewLog(format string, t time.Time) string {
+type Flog struct {
+	rand     *rand.Rand
+	gofakeit *gofakeit.Faker
+}
+
+func New(rand *rand.Rand, faker *gofakeit.Faker) *Flog {
+	return &Flog{rand: rand, gofakeit: faker}
+}
+
+func (f *Flog) LogLine(format string, t time.Time) string {
 	switch format {
 	case "apache_common":
-		return NewApacheCommonLog(t)
+		return f.NewApacheCommonLog(t)
 	case "apache_combined":
-		return NewApacheCombinedLog(t)
+		return f.NewApacheCombinedLog(t)
 	case "apache_error":
-		return NewApacheErrorLog(t)
+		return f.NewApacheErrorLog(t)
 	case "rfc3164":
-		return NewRFC3164Log(t)
+		return f.NewRFC3164Log(t)
 	case "rfc5424":
-		return NewRFC5424Log(t)
+		return f.NewRFC5424Log(t)
 	case "common_log":
-		return NewCommonLogFormat(t)
+		return f.NewCommonLogFormat(t)
 	case "json":
-		return NewJSONLogFormat(t)
+		return f.NewJSONLogFormat(t)
 	case "logfmt":
-		return NewLogFmtLogFormat(t)
+		return f.NewLogFmtLogFormat(t)
 	default:
 		return ""
 	}

--- a/flog/log.go
+++ b/flog/log.go
@@ -1,0 +1,151 @@
+package flog
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/brianvoe/gofakeit/v6"
+)
+
+const (
+	// ApacheCommonLog : {host} {user-identifier} {auth-user-id} [{datetime}] "{method} {request} {protocol}" {response-code} {bytes}
+	ApacheCommonLog = "%s - %s [%s] \"%s %s %s\" %d %d"
+	// ApacheCombinedLog : {host} {user-identifier} {auth-user-id} [{datetime}] "{method} {request} {protocol}" {response-code} {bytes} "{referrer}" "{agent}"
+	ApacheCombinedLog = "%s - %s [%s] \"%s %s %s\" %d %d \"%s\" \"%s\""
+	// ApacheErrorLog : [{timestamp}] [{module}:{severity}] [pid {pid}:tid {thread-id}] [client %{client}:{port}] %{message}
+	ApacheErrorLog = "[%s] [%s:%s] [pid %d:tid %d] [client %s:%d] %s"
+	// RFC3164Log : <priority>{timestamp} {hostname} {application}[{pid}]: {message}
+	RFC3164Log = "<%d>%s %s %s[%d]: %s"
+	// RFC5424Log : <priority>{version} {iso-timestamp} {hostname} {application} {pid} {message-id} {structured-data} {message}
+	RFC5424Log = "<%d>%d %s %s %s %d ID%d %s %s"
+	// CommonLogFormat : {host} {user-identifier} {auth-user-id} [{datetime}] "{method} {request} {protocol}" {response-code} {bytes}
+	CommonLogFormat = "%s - %s [%s] \"%s %s %s\" %d %d"
+	// JSONLogFormat : {"host": "{host}", "user-identifier": "{user-identifier}", "datetime": "{datetime}", "method": "{method}", "request": "{request}", "protocol": "{protocol}", "status", {status}, "bytes": {bytes}, "referer": "{referer}"}
+	JSONLogFormat = `{"host":"%s", "user-identifier":"%s", "datetime":"%s", "method": "%s", "request": "%s", "protocol":"%s", "status":%d, "bytes":%d, "referer": "%s"}`
+	// LogFmtLogFormat : host={host} user={user-identifier} timestamp={datetime} method={method} request="{request}" protocol={protocol} status={status} bytes={bytes} referer="{referer}"
+	LogFmtLogFormat = `host="%s" user=%s timestamp=%s method=%s request="%s" protocol=%s status=%d bytes=%d referer="%s"`
+)
+
+// NewApacheCommonLog creates a log string with apache common log format
+func NewApacheCommonLog(t time.Time) string {
+	return fmt.Sprintf(
+		ApacheCommonLog,
+		gofakeit.IPv4Address(),
+		RandAuthUserID(),
+		t.Format(Apache),
+		gofakeit.HTTPMethod(),
+		RandResourceURI(),
+		RandHTTPVersion(),
+		gofakeit.HTTPStatusCodeSimple(),
+		gofakeit.Number(0, 30000),
+	)
+}
+
+// NewApacheCombinedLog creates a log string with apache combined log format
+func NewApacheCombinedLog(t time.Time) string {
+	return fmt.Sprintf(
+		ApacheCombinedLog,
+		gofakeit.IPv4Address(),
+		RandAuthUserID(),
+		t.Format(Apache),
+		gofakeit.HTTPMethod(),
+		RandResourceURI(),
+		RandHTTPVersion(),
+		gofakeit.HTTPStatusCodeSimple(),
+		gofakeit.Number(30, 100000),
+		gofakeit.URL(),
+		gofakeit.UserAgent(),
+	)
+}
+
+// NewApacheErrorLog creates a log string with apache error log format
+func NewApacheErrorLog(t time.Time) string {
+	return fmt.Sprintf(
+		ApacheErrorLog,
+		t.Format(ApacheError),
+		gofakeit.Word(),
+		gofakeit.LogLevel("apache"),
+		gofakeit.Number(1, 10000),
+		gofakeit.Number(1, 10000),
+		gofakeit.IPv4Address(),
+		gofakeit.Number(1, 65535),
+		gofakeit.HackerPhrase(),
+	)
+}
+
+// NewRFC3164Log creates a log string with syslog (RFC3164) format
+func NewRFC3164Log(t time.Time) string {
+	return fmt.Sprintf(
+		RFC3164Log,
+		gofakeit.Number(0, 191),
+		t.Format(RFC3164),
+		strings.ToLower(gofakeit.Username()),
+		gofakeit.Word(),
+		gofakeit.Number(1, 10000),
+		gofakeit.HackerPhrase(),
+	)
+}
+
+// NewRFC5424Log creates a log string with syslog (RFC5424) format
+func NewRFC5424Log(t time.Time) string {
+	return fmt.Sprintf(
+		RFC5424Log,
+		gofakeit.Number(0, 191),
+		gofakeit.Number(1, 3),
+		t.Format(RFC5424),
+		gofakeit.DomainName(),
+		gofakeit.Word(),
+		gofakeit.Number(1, 10000),
+		gofakeit.Number(1, 1000),
+		"-", // TODO: structured data
+		gofakeit.HackerPhrase(),
+	)
+}
+
+// NewCommonLogFormat creates a log string with common log format
+func NewCommonLogFormat(t time.Time) string {
+	return fmt.Sprintf(
+		CommonLogFormat,
+		gofakeit.IPv4Address(),
+		RandAuthUserID(),
+		t.Format(CommonLog),
+		gofakeit.HTTPMethod(),
+		RandResourceURI(),
+		RandHTTPVersion(),
+		gofakeit.HTTPStatusCodeSimple(),
+		gofakeit.Number(0, 30000),
+	)
+}
+
+// NewJSONLogFormat creates a log string with json log format
+func NewJSONLogFormat(t time.Time) string {
+	return fmt.Sprintf(
+		JSONLogFormat,
+		gofakeit.IPv4Address(),
+		RandAuthUserID(),
+		t.Format(CommonLog),
+		gofakeit.HTTPMethod(),
+		RandResourceURI(),
+		RandHTTPVersion(),
+		gofakeit.HTTPStatusCodeSimple(),
+		gofakeit.Number(0, 30000),
+		gofakeit.URL(),
+	)
+}
+
+// NewLogFmtLogFormat creates a log string with logfmt log format
+func NewLogFmtLogFormat(t time.Time) string {
+	return fmt.Sprintf(
+		LogFmtLogFormat,
+		gofakeit.IPv4Address(),
+		RandAuthUserID(),
+		t.Format(RFC5424),
+		gofakeit.HTTPMethod(),
+		RandResourceURI(),
+		RandHTTPVersion(),
+		gofakeit.HTTPStatusCodeSimple(),
+		gofakeit.Number(0, 30000),
+		gofakeit.URL(),
+	)
+}

--- a/flog/log.go
+++ b/flog/log.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/brianvoe/gofakeit/v6"
 )
 
 const (
@@ -28,124 +26,124 @@ const (
 )
 
 // NewApacheCommonLog creates a log string with apache common log format
-func NewApacheCommonLog(t time.Time) string {
+func (f *Flog) NewApacheCommonLog(t time.Time) string {
 	return fmt.Sprintf(
 		ApacheCommonLog,
-		gofakeit.IPv4Address(),
-		RandAuthUserID(),
+		f.gofakeit.IPv4Address(),
+		f.RandAuthUserID(),
 		t.Format(Apache),
-		gofakeit.HTTPMethod(),
-		RandResourceURI(),
-		RandHTTPVersion(),
-		gofakeit.HTTPStatusCodeSimple(),
-		gofakeit.Number(0, 30000),
+		f.gofakeit.HTTPMethod(),
+		f.RandResourceURI(),
+		f.RandHTTPVersion(),
+		f.gofakeit.HTTPStatusCodeSimple(),
+		f.gofakeit.Number(0, 30000),
 	)
 }
 
 // NewApacheCombinedLog creates a log string with apache combined log format
-func NewApacheCombinedLog(t time.Time) string {
+func (f *Flog) NewApacheCombinedLog(t time.Time) string {
 	return fmt.Sprintf(
 		ApacheCombinedLog,
-		gofakeit.IPv4Address(),
-		RandAuthUserID(),
+		f.gofakeit.IPv4Address(),
+		f.RandAuthUserID(),
 		t.Format(Apache),
-		gofakeit.HTTPMethod(),
-		RandResourceURI(),
-		RandHTTPVersion(),
-		gofakeit.HTTPStatusCodeSimple(),
-		gofakeit.Number(30, 100000),
-		gofakeit.URL(),
-		gofakeit.UserAgent(),
+		f.gofakeit.HTTPMethod(),
+		f.RandResourceURI(),
+		f.RandHTTPVersion(),
+		f.gofakeit.HTTPStatusCodeSimple(),
+		f.gofakeit.Number(30, 100000),
+		f.gofakeit.URL(),
+		f.gofakeit.UserAgent(),
 	)
 }
 
 // NewApacheErrorLog creates a log string with apache error log format
-func NewApacheErrorLog(t time.Time) string {
+func (f *Flog) NewApacheErrorLog(t time.Time) string {
 	return fmt.Sprintf(
 		ApacheErrorLog,
 		t.Format(ApacheError),
-		gofakeit.Word(),
-		gofakeit.LogLevel("apache"),
-		gofakeit.Number(1, 10000),
-		gofakeit.Number(1, 10000),
-		gofakeit.IPv4Address(),
-		gofakeit.Number(1, 65535),
-		gofakeit.HackerPhrase(),
+		f.gofakeit.Word(),
+		f.gofakeit.LogLevel("apache"),
+		f.gofakeit.Number(1, 10000),
+		f.gofakeit.Number(1, 10000),
+		f.gofakeit.IPv4Address(),
+		f.gofakeit.Number(1, 65535),
+		f.gofakeit.HackerPhrase(),
 	)
 }
 
 // NewRFC3164Log creates a log string with syslog (RFC3164) format
-func NewRFC3164Log(t time.Time) string {
+func (f *Flog) NewRFC3164Log(t time.Time) string {
 	return fmt.Sprintf(
 		RFC3164Log,
-		gofakeit.Number(0, 191),
+		f.gofakeit.Number(0, 191),
 		t.Format(RFC3164),
-		strings.ToLower(gofakeit.Username()),
-		gofakeit.Word(),
-		gofakeit.Number(1, 10000),
-		gofakeit.HackerPhrase(),
+		strings.ToLower(f.gofakeit.Username()),
+		f.gofakeit.Word(),
+		f.gofakeit.Number(1, 10000),
+		f.gofakeit.HackerPhrase(),
 	)
 }
 
 // NewRFC5424Log creates a log string with syslog (RFC5424) format
-func NewRFC5424Log(t time.Time) string {
+func (f *Flog) NewRFC5424Log(t time.Time) string {
 	return fmt.Sprintf(
 		RFC5424Log,
-		gofakeit.Number(0, 191),
-		gofakeit.Number(1, 3),
+		f.gofakeit.Number(0, 191),
+		f.gofakeit.Number(1, 3),
 		t.Format(RFC5424),
-		gofakeit.DomainName(),
-		gofakeit.Word(),
-		gofakeit.Number(1, 10000),
-		gofakeit.Number(1, 1000),
+		f.gofakeit.DomainName(),
+		f.gofakeit.Word(),
+		f.gofakeit.Number(1, 10000),
+		f.gofakeit.Number(1, 1000),
 		"-", // TODO: structured data
-		gofakeit.HackerPhrase(),
+		f.gofakeit.HackerPhrase(),
 	)
 }
 
 // NewCommonLogFormat creates a log string with common log format
-func NewCommonLogFormat(t time.Time) string {
+func (f *Flog) NewCommonLogFormat(t time.Time) string {
 	return fmt.Sprintf(
 		CommonLogFormat,
-		gofakeit.IPv4Address(),
-		RandAuthUserID(),
+		f.gofakeit.IPv4Address(),
+		f.RandAuthUserID(),
 		t.Format(CommonLog),
-		gofakeit.HTTPMethod(),
-		RandResourceURI(),
-		RandHTTPVersion(),
-		gofakeit.HTTPStatusCodeSimple(),
-		gofakeit.Number(0, 30000),
+		f.gofakeit.HTTPMethod(),
+		f.RandResourceURI(),
+		f.RandHTTPVersion(),
+		f.gofakeit.HTTPStatusCodeSimple(),
+		f.gofakeit.Number(0, 30000),
 	)
 }
 
 // NewJSONLogFormat creates a log string with json log format
-func NewJSONLogFormat(t time.Time) string {
+func (f *Flog) NewJSONLogFormat(t time.Time) string {
 	return fmt.Sprintf(
 		JSONLogFormat,
-		gofakeit.IPv4Address(),
-		RandAuthUserID(),
+		f.gofakeit.IPv4Address(),
+		f.RandAuthUserID(),
 		t.Format(CommonLog),
-		gofakeit.HTTPMethod(),
-		RandResourceURI(),
-		RandHTTPVersion(),
-		gofakeit.HTTPStatusCodeSimple(),
-		gofakeit.Number(0, 30000),
-		gofakeit.URL(),
+		f.gofakeit.HTTPMethod(),
+		f.RandResourceURI(),
+		f.RandHTTPVersion(),
+		f.gofakeit.HTTPStatusCodeSimple(),
+		f.gofakeit.Number(0, 30000),
+		f.gofakeit.URL(),
 	)
 }
 
 // NewLogFmtLogFormat creates a log string with logfmt log format
-func NewLogFmtLogFormat(t time.Time) string {
+func (f *Flog) NewLogFmtLogFormat(t time.Time) string {
 	return fmt.Sprintf(
 		LogFmtLogFormat,
-		gofakeit.IPv4Address(),
-		RandAuthUserID(),
+		f.gofakeit.IPv4Address(),
+		f.RandAuthUserID(),
 		t.Format(RFC5424),
-		gofakeit.HTTPMethod(),
-		RandResourceURI(),
-		RandHTTPVersion(),
-		gofakeit.HTTPStatusCodeSimple(),
-		gofakeit.Number(0, 30000),
-		gofakeit.URL(),
+		f.gofakeit.HTTPMethod(),
+		f.RandResourceURI(),
+		f.RandHTTPVersion(),
+		f.gofakeit.HTTPStatusCodeSimple(),
+		f.gofakeit.Number(0, 30000),
+		f.gofakeit.URL(),
 	)
 }

--- a/flog/random.go
+++ b/flog/random.go
@@ -1,0 +1,32 @@
+package flog
+
+import (
+	"math/rand"
+	"net/url"
+	"strings"
+
+	"github.com/brianvoe/gofakeit/v6"
+)
+
+// RandResourceURI generates a random resource URI
+func RandResourceURI() string {
+	var uri string
+	num := gofakeit.Number(1, 4)
+	for i := 0; i < num; i++ {
+		uri += "/" + url.QueryEscape(gofakeit.BS())
+	}
+	uri = strings.ToLower(uri)
+	return uri
+}
+
+// RandAuthUserID generates a random auth user id
+func RandAuthUserID() string {
+	candidates := []string{"-", strings.ToLower(gofakeit.Username())}
+	return candidates[rand.Intn(2)]
+}
+
+// RandHTTPVersion returns a random http version
+func RandHTTPVersion() string {
+	versions := []string{"HTTP/1.0", "HTTP/1.1", "HTTP/2.0"}
+	return versions[rand.Intn(3)]
+}

--- a/flog/random.go
+++ b/flog/random.go
@@ -1,32 +1,29 @@
 package flog
 
 import (
-	"math/rand"
 	"net/url"
 	"strings"
-
-	"github.com/brianvoe/gofakeit/v6"
 )
 
 // RandResourceURI generates a random resource URI
-func RandResourceURI() string {
+func (f *Flog) RandResourceURI() string {
 	var uri string
-	num := gofakeit.Number(1, 4)
+	num := f.gofakeit.Number(1, 4)
 	for i := 0; i < num; i++ {
-		uri += "/" + url.QueryEscape(gofakeit.BS())
+		uri += "/" + url.QueryEscape(f.gofakeit.BS())
 	}
 	uri = strings.ToLower(uri)
 	return uri
 }
 
 // RandAuthUserID generates a random auth user id
-func RandAuthUserID() string {
-	candidates := []string{"-", strings.ToLower(gofakeit.Username())}
-	return candidates[rand.Intn(2)]
+func (f *Flog) RandAuthUserID() string {
+	candidates := []string{"-", strings.ToLower(f.gofakeit.Username())}
+	return candidates[f.rand.Intn(2)]
 }
 
 // RandHTTPVersion returns a random http version
-func RandHTTPVersion() string {
+func (f *Flog) RandHTTPVersion() string {
 	versions := []string{"HTTP/1.0", "HTTP/1.1", "HTTP/2.0"}
-	return versions[rand.Intn(3)]
+	return versions[f.rand.Intn(3)]
 }

--- a/flog/time.go
+++ b/flog/time.go
@@ -1,0 +1,10 @@
+package flog
+
+// Custom predefined layouts
+const (
+	Apache      = "02/Jan/2006:15:04:05 -0700"
+	ApacheError = "Mon Jan 02 15:04:05 2006"
+	RFC3164     = "Jan 02 15:04:05"
+	RFC5424     = "2006-01-02T15:04:05.000Z"
+	CommonLog   = "02/Jan/2006:15:04:05 -0700"
+)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/golang/snappy v0.0.4
 	github.com/grafana/loki v1.6.2-0.20230310093109-e2ac2d50e2d7
 	github.com/mailru/easyjson v0.7.7
-	github.com/mingrammer/flog v0.4.3
 	github.com/prometheus/common v0.42.0
 	go.k6.io/k6 v0.43.1
 )
@@ -22,7 +21,6 @@ require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/armon/go-metrics v0.4.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/brianvoe/gofakeit v3.11.5+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.4.0 // indirect
@@ -88,7 +86,6 @@ require (
 	github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
@@ -120,8 +117,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/mingrammer/flog => github.com/chaudum/flog v0.4.4-0.20220419113107-eb2f67f18b99
 
 replace google.golang.org/grpc => google.golang.org/grpc v1.45.0
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/mailru/easyjson v0.7.7
 	github.com/mingrammer/flog v0.4.3
 	github.com/prometheus/common v0.42.0
-	github.com/sirupsen/logrus v1.9.0
 	go.k6.io/k6 v0.43.1
 )
 
@@ -87,6 +86,7 @@ require (
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
 	github.com/sercand/kuberesolver v2.4.0+incompatible // indirect
 	github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e // indirect
+	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/grafana/loki v1.6.2-0.20230310093109-e2ac2d50e2d7
 	github.com/mailru/easyjson v0.7.7
 	github.com/prometheus/common v0.42.0
+	github.com/sirupsen/logrus v1.9.0
 	go.k6.io/k6 v0.43.1
 )
 
@@ -84,7 +85,6 @@ require (
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
 	github.com/sercand/kuberesolver v2.4.0+incompatible // indirect
 	github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e // indirect
-	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/stretchr/testify v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-bou.ke/monkey v1.0.1 h1:zEMLInw9xvNakzUUPjfS4Ds6jYPqCFx3m7bRmG5NH2U=
-bou.ke/monkey v1.0.1/go.mod h1:FgHuK96Rv2Nlf+0u1OOVDpCMdsWyOFmeeketDHE7LIg=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6AU=
@@ -94,8 +92,6 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/brianvoe/gofakeit v3.11.5+incompatible h1:AKzhOU0ycSDhjDbIeJ/V9wiiIMmyg9XzAg9muTXc2nk=
-github.com/brianvoe/gofakeit v3.11.5+incompatible/go.mod h1:kfwdRA90vvNhPutZWfH7WPaDzUjz+CZFqG+rPkOjGOc=
 github.com/brianvoe/gofakeit/v6 v6.9.0 h1:UCGhPCKLiqBc910TKS7LcOGf74NozftibFCbGIS6GZQ=
 github.com/brianvoe/gofakeit/v6 v6.9.0/go.mod h1:palrJUk4Fyw38zIFB/uBZqsgzW5VsNllhHKKwAebzew=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -103,8 +99,6 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chaudum/flog v0.4.4-0.20220419113107-eb2f67f18b99 h1:jAtWDP8BytgtCzaxDzK/fZusSQbIaK0d9B6xwPpQCoU=
-github.com/chaudum/flog v0.4.4-0.20220419113107-eb2f67f18b99/go.mod h1:HnDRe7HbtBOHZ4qeD+yCHXM8pR7qq7hl1rUI/tLGDKA=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -138,7 +132,6 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.14.1 h1:qfhVLaG5s+nCROl1zJsZRxFeYrHLqWroPOQ8BWiNb4w=
@@ -400,7 +393,6 @@ github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKju
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/miekg/dns v1.1.50 h1:DQUfb9uc6smULcREF09Uc+/Gd46YWqJd5DbpPE9xkcA=
 github.com/miekg/dns v1.1.50/go.mod h1:e3IlAVfNqAllflbibAZEWOXOQ+Ynzk/dDozDxY7XnME=
-github.com/mingrammer/cfmt v1.0.0/go.mod h1:D2ZhJie9PURSfLSb+DB3l+aE32t+K7B596FI6rdm/pI=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -518,15 +510,11 @@ github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/afero v1.9.3 h1:41FoI0fD7OR7mGcKE/aOiLkGreyf8ifIOQmJANWogMk=
 github.com/spf13/afero v1.9.3/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
-github.com/spf13/pflag v1.0.0/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -733,7 +721,6 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.0.0-20180416112224-2f57af4873d0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/loki.go
+++ b/loki.go
@@ -276,6 +276,7 @@ func (r *Loki) client(c goja.ConstructorCall) *goja.Object {
 		rand:    rand,
 		faker:   faker,
 		flog:    flog,
+		labels:  transformLabelPool(config.Labels),
 	}).ToObject(rt)
 }
 


### PR DESCRIPTION
Look at this commit by commit. The summary is:
- I added support for an object-based config, so we can add additional configuration options without exploding the number of `loki.Config()` positional parameters
- Removed the artificial restriction for creating a `Config` in the init context
- Inlined a partial copy of the github.com/chaudum/flog dependency and refactored all pseudo-random data generation to be deterministic, controlled by the initial `randSeed` value in every `Config`.


:warning: This PR also fixes a major bug where `pushParameterized()` didn't send the specified amount of data, it only sent `1/numStreams`! See https://github.com/grafana/xk6-loki/pull/59/commits/243abf4e1d37854d7b19f53c3e1fb0b1c3331efb