### PR TITLE
Allow to configure examples via env

### DIFF
--- a/examples/custom-labels.js
+++ b/examples/custom-labels.js
@@ -1,7 +1,37 @@
 import { check, sleep } from 'k6';
 import loki from 'k6/x/loki';
 
-const BASE_URL = "http://localhost:3100";
+/*
+ * Host name with port
+ * @constant {string}
+ */
+const HOST = __ENV.LOKI_ADDR || fail("provide LOKI_ADDR when starting k6");
+
+/**
+ * Optional name of the Loki tenant
+ * @constant {string}
+ */
+const TENANT_ID = __ENV.LOKI_TENANT_ID || '';
+
+/**
+ * Optional access token of the Loki tenant with logs:write and logs:read permissions
+ * @constant {string}
+ */
+const ACCESS_TOKEN = __ENV.LOKI_ACCESS_TOKEN || '';
+
+/**
+ * Configures the protocol scheme used for requests.
+ * @constant {string}
+ */
+const SCHEME = __ENV.K6_SCHEME || 'http';
+
+/**
+ * URL used for push and query requests
+ * Path is automatically appended by the client
+ * @constant {string}
+ */
+const BASE_URL = `${SCHEME}://${TENANT_ID}:${ACCESS_TOKEN}@${HOST}`;
+
 const KB = 1024;
 const MB = KB * KB;
 

--- a/examples/read-scenario.js
+++ b/examples/read-scenario.js
@@ -5,26 +5,32 @@ import loki from 'k6/x/loki';
  * Host name with port
  * @constant {string}
  */
-const HOST = "xxx.grafana.net:3100";
+const HOST = __ENV.LOKI_ADDR || fail("provide LOKI_ADDR when starting k6");
 
 /**
- * Name of the Loki tenant
+ * Optional name of the Loki tenant
  * @constant {string}
  */
-const TENANT_ID = __ENV.LOKI_TENANT_ID || fail("provide LOKI_TENANT_ID when starting k6");
+const TENANT_ID = __ENV.LOKI_TENANT_ID || '';
 
 /**
- * Access token of the Loki tenant with logs:write and logs:read permissions
+ * Optional access token of the Loki tenant with logs:write and logs:read permissions
  * @constant {string}
  */
-const ACCESS_TOKEN = __ENV.LOKI_ACCESS_TOKEN || fail("provide LOKI_ACCESS_TOKEN when starting k6");
+const ACCESS_TOKEN = __ENV.LOKI_ACCESS_TOKEN || '';
+
+/**
+ * Configures the protocol scheme used for requests.
+ * @constant {string}
+ */
+const SCHEME = __ENV.K6_SCHEME || 'http';
 
 /**
  * URL used for push and query requests
  * Path is automatically appended by the client
  * @constant {string}
  */
-const BASE_URL = `https://${TENANT_ID}:${ACCESS_TOKEN}@${HOST}`;
+const BASE_URL = `${SCHEME}://${TENANT_ID}:${ACCESS_TOKEN}@${HOST}`;
 
 /**
  * Amount of virtual users (VUs)

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,12 +1,36 @@
 import {sleep, check} from 'k6';
 import loki from 'k6/x/loki';
 
+/*
+ * Host name with port
+ * @constant {string}
+ */
+const HOST = __ENV.LOKI_ADDR || fail("provide LOKI_ADDR when starting k6");
+
+/**
+ * Optional name of the Loki tenant
+ * @constant {string}
+ */
+const TENANT_ID = __ENV.LOKI_TENANT_ID || '';
+
+/**
+ * Optional access token of the Loki tenant with logs:write and logs:read permissions
+ * @constant {string}
+ */
+const ACCESS_TOKEN = __ENV.LOKI_ACCESS_TOKEN || '';
+
+/**
+ * Configures the protocol scheme used for requests.
+ * @constant {string}
+ */
+const SCHEME = __ENV.K6_SCHEME || 'http';
+
 /**
  * URL used for push and query requests
  * Path is automatically appended by the client
  * @constant {string}
  */
-const BASE_URL = `http://localhost:3100`;
+const BASE_URL = `${SCHEME}://${TENANT_ID}:${ACCESS_TOKEN}@${HOST}`;
 
 /**
  * Helper constant for byte values

--- a/examples/write-scenario.js
+++ b/examples/write-scenario.js
@@ -5,26 +5,32 @@ import loki from 'k6/x/loki';
  * Host name with port
  * @constant {string}
  */
-const HOST = "xxx.grafana.net:3100";
+const HOST = __ENV.LOKI_ADDR || fail("provide LOKI_ADDR when starting k6");
 
 /**
- * Name of the Loki tenant
+ * Optional name of the Loki tenant
  * @constant {string}
  */
-const TENANT_ID = __ENV.LOKI_TENANT_ID || fail("provide LOKI_TENANT_ID when starting k6");
+const TENANT_ID = __ENV.LOKI_TENANT_ID || '';
 
 /**
- * Access token of the Loki tenant with logs:write and logs:read permissions
+ * Optional access token of the Loki tenant with logs:write and logs:read permissions
  * @constant {string}
  */
-const ACCESS_TOKEN = __ENV.LOKI_ACCESS_TOKEN || fail("provide LOKI_ACCESS_TOKEN when starting k6");
+const ACCESS_TOKEN = __ENV.LOKI_ACCESS_TOKEN || '';
+
+/**
+ * Configures the protocol scheme used for requests.
+ * @constant {string}
+ */
+const SCHEME = __ENV.K6_SCHEME || 'http';
 
 /**
  * URL used for push and query requests
  * Path is automatically appended by the client
  * @constant {string}
  */
-const BASE_URL = `https://${TENANT_ID}:${ACCESS_TOKEN}@${HOST}`;
+const BASE_URL = `${SCHEME}://${TENANT_ID}:${ACCESS_TOKEN}@${HOST}`;
 
 /**
  * Minimum amount of virtual users (VUs)


### PR DESCRIPTION
With the following PR users do not need to edit the examples anymore.
This is inspired from [Mimir](https://github.com/grafana/mimir/blob/651dcd93f709943a8349532c8438e2993dd3b056/operations/k6/load-testing-with-k6.js#L1)