### PR TITLE
Protect and fix panics with specific min/max batch size

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -162,7 +162,11 @@ func (c *Client) newBatch(numStreams, minBatchSize, maxBatchSize int) *Batch {
 		hostname = "localhost"
 	}
 
-	maxSizePerStream := (minBatchSize + c.rand.Intn(maxBatchSize-minBatchSize)) / numStreams
+	maxSizePerStream := minBatchSize
+	if minBatchSize != maxBatchSize {
+		maxSizePerStream += c.rand.Intn(maxBatchSize - minBatchSize)
+	}
+	maxSizePerStream /= numStreams
 
 	for i := 0; i < numStreams; i++ {
 		labels := c.getRandomLabelSet()

--- a/client.go
+++ b/client.go
@@ -244,6 +244,9 @@ func (c *Client) PushParametrized(streams, minBatchSize, maxBatchSize int) (http
 }
 
 func (c *Client) PushParameterized(streams, minBatchSize, maxBatchSize int) (httpext.Response, error) {
+	if minBatchSize > maxBatchSize {
+		return *httpext.NewResponse(), errors.New("minimum batch size needs to be smaller or equal to max batch size")
+	}
 	state := c.vu.State()
 	if state == nil {
 		return *httpext.NewResponse(), errors.New("state is nil")


### PR DESCRIPTION
Support them being equal and throw an exception when they aren't instead of panicking.