### PR TITLE
chore: Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
           go-version: 1.21.x
           cache: false
@@ -41,11 +41,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
           go-version: 1.21.x
           cache: false


### PR DESCRIPTION
## Summary

- Pin all public GitHub Action tag references to full commit SHAs for supply chain security
- Version tags preserved as inline comments for readability
- Internal `grafana/` workflow references left as-is

## Why

Tag-based action references are mutable, a compromised tag can inject malicious code into CI without any visible change in workflow files. Pinning to immutable commit SHAs prevents this attack vector.